### PR TITLE
fix  #6923 dnnHelperTip causes horizontal scrollbar when moving mouse…

### DIFF
--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -228,7 +228,7 @@ namespace DotNetNuke.Framework
             var ctlSkin = this.GetSkin();
 
             this.clientResourceController.RegisterPathNameAlias("SkinPath", this.CurrentSkinPath);
-            
+
             // check for and read skin package level doctype
             this.SetSkinDoctype();
 
@@ -454,7 +454,6 @@ namespace DotNetNuke.Framework
 
             // moved this call to OnInit to avoid incorrect CurrentSkinPath if using fallback skin
             ////this.clientResourceController.RegisterPathNameAlias("SkinPath", this.CurrentSkinPath);
-
 
             // redirect to a specific tab based on name
             if (!string.IsNullOrEmpty(this.Request.QueryString["tabname"]))
@@ -880,4 +879,3 @@ namespace DotNetNuke.Framework
         }
     }
 }
-

--- a/DNN Platform/Website/Resources/Shared/scripts/dnn.jquery.js
+++ b/DNN Platform/Website/Resources/Shared/scripts/dnn.jquery.js
@@ -693,6 +693,16 @@
 
             $pd.on('mousemove', function (e) {
                 var x = e.pageX; var y = e.pageY;
+                // Fix: Check if tooltip overflows the right edge of the window
+                var tipWidth = pd.tooltipWrapperInner.outerWidth();
+                var winWidth = $(window).width();
+                
+                // Safety buffer of 20px for vertical scrollbar
+                if ((x + tipWidth) > (winWidth - 20)) {
+                    // Clamp x position to fit inside the screen
+                    x = winWidth - tipWidth - 20; 
+                }
+                
                 var pos = $('body').css('position');
                 if (pos == 'relative') y -= 38;
                 pd.tooltipWrapper.css({ left: x + 'px', top: y + 'px', 'z-index': '99999' });
@@ -4320,4 +4330,5 @@
     Sys.WebForms.PageRequestManager.getInstance().add_endRequest(dnnInitCustomisedCtrls);
     $(dnnInitCustomisedCtrls);
     handlerSendVerificationMailLink();
+
 })(jQuery);


### PR DESCRIPTION
… to the right edge (dnn.jquery.js)

fix  #6923 
dnnHelperTip causes horizontal scrollbar when moving mouse to the right edge (dnn.jquery.js) ## Description
This PR fixes issue #6923 where the `dnnHelperTip` causes a horizontal scrollbar when the mouse moves to the right edge of the screen. I added logic to calculate the viewport width and constrain the tooltip position.

## Changes
- Modified `dnn.jquery.js` to clamp the tooltip X coordinate within the window width.

## RFC / Future Consideration
While this PR resolves the immediate scrolling issue, I would like to propose (RFC) fully deprecating this JavaScript-based "mouse-follow" behavior in favor of a pure CSS implementation. Moving to CSS would simplify the codebase and provide a lighter, more stable UI/UX for the Admin interface. PS: If there is consensus on this approach, I can proceed with a PR to refactor this feature. The helper tip will be static and centered relative to the Module title, completely removing the mouse-tracking behavior.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
